### PR TITLE
Fix RSS polling after browser restart

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -8,6 +8,18 @@ chrome.runtime.onInstalled.addListener(async () => {
     await init_rss_poller()
 })
 
+// also initialise polling when the extension starts up after a browser restart
+chrome.runtime.onStartup.addListener(() => {
+    init_rss_poller().catch(err =>
+        console.error("Failed to init RSS poller on startup", err)
+    )
+})
+
+// ensure polling is scheduled whenever the service worker loads
+init_rss_poller().catch(err =>
+    console.error("Failed to initialise RSS poller", err)
+)
+
 // Helper to promisify chrome.storage.sync.get for settings
 const get_stored_settings = (): Promise<Settings | undefined> =>
     new Promise(resolve => {

--- a/src/background/pull_feed.ts
+++ b/src/background/pull_feed.ts
@@ -77,9 +77,12 @@ export const on_alarm = (alarm: chrome.alarms.Alarm): void => {
     if (alarm.name === "rss_poll") poll_feed()
 }
 
-export async function init_rss_poller(): Promise<void>{
-    let user_settings = (await chrome.storage.sync.get("settings"))["settings"] as Settings
-
-    chrome.alarms.create("rss_poll", { periodInMinutes: user_settings.rss_feed_pull_interval })
-    chrome.alarms.onAlarm.addListener(on_alarm)
+export async function init_rss_poller(): Promise<void> {
+    const user_settings = (await chrome.storage.sync.get("settings"))["settings"] as Settings
+    chrome.alarms.create("rss_poll", {
+        periodInMinutes: user_settings.rss_feed_pull_interval,
+    })
 }
+
+// ensure the alarm listener is always registered when the service worker starts
+chrome.alarms.onAlarm.addListener(on_alarm)


### PR DESCRIPTION
## Summary
- keep the alarm listener registered when the service worker loads
- initialize RSS polling on browser startup and whenever the service worker starts

## Testing
- `bun x tsc --noEmit` *(fails: Cannot find name 'chrome')*