### PR TITLE
refactor: declare reduce_width.css as manifest content_script

### DIFF
--- a/public/reduce_width.css
+++ b/public/reduce_width.css
@@ -1,4 +1,4 @@
-#content {
+body.ultrabox-reduce-content-width #content {
     max-width: 1500px;
     margin: 0 auto;
 }

--- a/src/background/events/injects/reduce_width.ts
+++ b/src/background/events/injects/reduce_width.ts
@@ -1,5 +1,9 @@
 import { Module } from "../../../types/module"
 
+// reduce_width.css is declared as a manifest-level content_script (see
+// wxt.config.ts) and is always present on matching pages. Its rules are
+// scoped to body.ultrabox-reduce-content-width, so this module enables
+// the styling by setting that class on schoolbox pages.
 export default <Module>{
     setting: s => {
         return s.reduce_content_width
@@ -8,9 +12,11 @@ export default <Module>{
         return helper_fns.is_schoolbox_page
     },
     action: async base => {
-        await chrome.scripting.insertCSS({
+        await chrome.scripting.executeScript({
             target: { tabId: base.tab_id },
-            files: ["reduce_width.css"],
+            func: () => {
+                document.body.classList.add("ultrabox-reduce-content-width")
+            },
         })
     },
 }

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -29,4 +29,18 @@ export default defineConfig({
             },
         ],
     },
+    hooks: {
+        // Declare pure-CSS injections as manifest-level content scripts so
+        // the browser loads them automatically instead of going through
+        // chrome.scripting.insertCSS at runtime. The rules themselves are
+        // gated by a body class (toggled by the corresponding inject module)
+        // so the setting still controls whether the styles apply.
+        "build:manifestGenerated": (_wxt, manifest) => {
+            manifest.content_scripts ??= []
+            manifest.content_scripts.push({
+                matches: ["<all_urls>"],
+                css: ["reduce_width.css"],
+            })
+        },
+    },
 })


### PR DESCRIPTION
## Summary

- Added a WXT `build:manifestGenerated` hook to declare `reduce_width.css` as a manifest-level `content_scripts` entry (matches `<all_urls>`), so the browser loads the stylesheet automatically.
- Replaced the runtime `chrome.scripting.insertCSS` call in `src/background/events/injects/reduce_width.ts` with a tiny `executeScript` that adds the `ultrabox-reduce-content-width` class to `<body>`. Existing `setting` and `is_schoolbox_page` gating is preserved.
- Scoped the CSS rule in `public/reduce_width.css` to `body.ultrabox-reduce-content-width #content` so the always-present stylesheet only takes effect when the module enables it.

This demonstrates the pattern; the schooltape-related pure-CSS injectors (`launcher_styles.css`, `post_history_styles.css`, `news_search_styles.css`) are left alone for a follow-up since they have richer conditional logic and shared layering with non-schooltape variants.

## Test plan

- [x] `npm install --ignore-scripts` succeeds (bun install on Windows fell back to npm as the repo conventions allow)
- [x] `npx wxt prepare` succeeds
- [x] `npm run typecheck` passes
- [x] `npm run build` produces output
- [x] `.output/chrome-mv3/manifest.json` contains `"content_scripts":[{"matches":["<all_urls>"],"css":["reduce_width.css"]}]`
- [ ] Manual browser verification: enable the "Reduce content width" module in the popup on a Schoolbox page, confirm `#content` is centered at max 1500px; disable + reload, confirm rule no longer applies. (Setting toggle is gated by full page reload, matching the original behavior.)